### PR TITLE
Update stlink_usb.c

### DIFF
--- a/src/jtag/drivers/stlink_usb.c
+++ b/src/jtag/drivers/stlink_usb.c
@@ -4605,7 +4605,7 @@ static int stlink_usb_cnt_buf_rw_queue(const struct dap_queue *q, unsigned int l
 
 static int stlink_usb_mem_rw_queue(void *handle, const struct dap_queue *q, unsigned int len, unsigned int *skip)
 {
-	unsigned int cnt, misc_items;
+	unsigned int cnt, misc_items = 0;
 	int retval;
 
 	unsigned int cnt_misc = stlink_usb_cnt_misc_rw_queue(handle, q, len, &misc_items);


### PR DESCRIPTION
`misc_items` variable is uninitialzed in function `stlink_dap_op_queue_run_internal`, therefore `stlink_usb.c` fails to compile when the option `-Werror=maybe-uninitialized` is set (I've not set it intentionally, so I assume this is the default).

There is already an issue in the ST Forum: https://community.st.com/s/question/0D53W00001JCSdaSAH/how-to-connect-stm32h745idisco-with-openocd-using-openocd-
```
src/jtag/drivers/stlink_usb.c: In function ‘stlink_dap_op_queue_run_internal’:
src/jtag/drivers/stlink_usb.c:4608:20: error: ‘misc_items’ error: ‘misc_items’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
```
