### PR TITLE
fix gcc 14.x builds

### DIFF
--- a/src/flash/nor/ambiqmicro.c
+++ b/src/flash/nor/ambiqmicro.c
@@ -124,7 +124,7 @@ FLASH_BANK_COMMAND_HANDLER(ambiqmicro_flash_bank_command)
 	if (CMD_ARGC < 6)
 		return ERROR_COMMAND_SYNTAX_ERROR;
 
-	ambiqmicro_info = calloc(sizeof(struct ambiqmicro_flash_bank), 1);
+	ambiqmicro_info = calloc(1, sizeof(struct ambiqmicro_flash_bank));
 
 	bank->driver_priv = ambiqmicro_info;
 

--- a/src/flash/nor/kinetis.c
+++ b/src/flash/nor/kinetis.c
@@ -898,7 +898,7 @@ FLASH_BANK_COMMAND_HANDLER(kinetis_flash_bank_command)
 	k_chip = kinetis_get_chip(target);
 
 	if (!k_chip) {
-		k_chip = calloc(sizeof(struct kinetis_chip), 1);
+		k_chip = calloc(1, sizeof(struct kinetis_chip));
 		if (!k_chip) {
 			LOG_ERROR("No memory");
 			return ERROR_FAIL;
@@ -999,7 +999,7 @@ static int kinetis_create_missing_banks(struct kinetis_chip *k_chip)
 					 bank_idx - k_chip->num_pflash_blocks);
 		}
 
-		bank = calloc(sizeof(struct flash_bank), 1);
+		bank = calloc(1, sizeof(struct flash_bank));
 		if (!bank)
 			return ERROR_FAIL;
 

--- a/src/flash/nor/max32xxx.c
+++ b/src/flash/nor/max32xxx.c
@@ -87,7 +87,7 @@ FLASH_BANK_COMMAND_HANDLER(max32xxx_flash_bank_command)
 		return ERROR_FLASH_BANK_INVALID;
 	}
 
-	info = calloc(sizeof(struct max32xxx_flash_bank), 1);
+	info = calloc(1, sizeof(struct max32xxx_flash_bank));
 	COMMAND_PARSE_NUMBER(uint, CMD_ARGV[2], info->flash_size);
 	COMMAND_PARSE_NUMBER(uint, CMD_ARGV[6], info->flc_base);
 	COMMAND_PARSE_NUMBER(uint, CMD_ARGV[7], info->sector_size);

--- a/src/flash/nor/msp432.c
+++ b/src/flash/nor/msp432.c
@@ -937,7 +937,7 @@ static int msp432_probe(struct flash_bank *bank)
 
 	if (is_main && MSP432P4 == msp432_bank->family_type) {
 		/* Create the info flash bank needed by MSP432P4 variants */
-		struct flash_bank *info = calloc(sizeof(struct flash_bank), 1);
+		struct flash_bank *info = calloc(1, sizeof(struct flash_bank));
 		if (!info)
 			return ERROR_FAIL;
 

--- a/src/flash/nor/stellaris.c
+++ b/src/flash/nor/stellaris.c
@@ -453,7 +453,7 @@ FLASH_BANK_COMMAND_HANDLER(stellaris_flash_bank_command)
 	if (CMD_ARGC < 6)
 		return ERROR_COMMAND_SYNTAX_ERROR;
 
-	stellaris_info = calloc(sizeof(struct stellaris_flash_bank), 1);
+	stellaris_info = calloc(1, sizeof(struct stellaris_flash_bank));
 	bank->base = 0x0;
 	bank->driver_priv = stellaris_info;
 

--- a/src/flash/nor/stldr_driver.c
+++ b/src/flash/nor/stldr_driver.c
@@ -262,7 +262,7 @@ static int stldr_parse(struct flash_bank *bank, const char *stldr_path)
 				return ERROR_FAIL;
 			}
 
-			struct stldr_section *section = calloc(sizeof(struct stldr_section), 1);
+			struct stldr_section *section = calloc(1, sizeof(struct stldr_section));
 			if (!section) {
 				free(content);
 				return ERROR_FAIL;
@@ -396,7 +396,7 @@ FLASH_BANK_COMMAND_HANDLER(stldr_flash_bank_command)
 	if (CMD_ARGC != 6 && CMD_ARGC != 7)
 		return ERROR_COMMAND_SYNTAX_ERROR;
 
-	stldr_info = calloc(sizeof(struct stldr_flash_bank), 1);
+	stldr_info = calloc(1, sizeof(struct stldr_flash_bank));
 	if (!stldr_info) {
 		LOG_ERROR("Out of memory");
 		return ERROR_FAIL;

--- a/src/flash/nor/stm32f2x.c
+++ b/src/flash/nor/stm32f2x.c
@@ -1018,7 +1018,7 @@ static int stm32x_probe(struct flash_bank *bank)
 		assert(num_sectors > 0);
 
 		bank->num_sectors = num_sectors;
-		bank->sectors = calloc(sizeof(struct flash_sector), num_sectors);
+		bank->sectors = calloc(num_sectors, sizeof(struct flash_sector));
 
 		if (stm32x_otp_is_f7(bank))
 			bank->size = STM32F7_OTP_SIZE;

--- a/src/jtag/drivers/ulink.c
+++ b/src/jtag/drivers/ulink.c
@@ -5,6 +5,7 @@
  *   <martin.schmoelzer@student.tuwien.ac.at>                              *
  ***************************************************************************/
 
+#include <stdint.h>
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -1473,7 +1474,7 @@ static int ulink_queue_scan(struct ulink *device, struct jtag_command *cmd)
 
 	/* Allocate TDO buffer if required */
 	if ((type == SCAN_IN) || (type == SCAN_IO)) {
-		tdo_buffer_start = calloc(sizeof(uint8_t), scan_size_bytes);
+		tdo_buffer_start = calloc(scan_size_bytes, sizeof(uint8_t));
 
 		if (!tdo_buffer_start)
 			return ERROR_FAIL;

--- a/src/target/arc_jtag.c
+++ b/src/target/arc_jtag.c
@@ -298,7 +298,7 @@ static int arc_jtag_read_registers(struct arc_jtag *jtag_info, uint32_t type,
 			ARC_JTAG_READ_FROM_CORE_REG : ARC_JTAG_READ_FROM_AUX_REG);
 	arc_jtag_enque_set_transaction(jtag_info, transaction, TAP_DRPAUSE);
 
-	uint8_t *data_buf = calloc(sizeof(uint8_t), count * 4);
+	uint8_t *data_buf = calloc(count*4, sizeof(uint8_t));
 
 	arc_jtag_enque_register_rw(jtag_info, addr, data_buf, NULL, count);
 
@@ -498,7 +498,7 @@ int arc_jtag_read_memory(struct arc_jtag *jtag_info, uint32_t addr,
 	if (!count)
 		return ERROR_OK;
 
-	data_buf = calloc(sizeof(uint8_t), count * 4);
+	data_buf = calloc(count * 4, sizeof(uint8_t));
 	arc_jtag_enque_reset_transaction(jtag_info);
 
 	/* We are reading from memory. */

--- a/src/target/nds32.c
+++ b/src/target/nds32.c
@@ -381,7 +381,7 @@ static const struct reg_arch_type nds32_reg_access_type_64 = {
 static struct reg_cache *nds32_build_reg_cache(struct target *target,
 		struct nds32 *nds32)
 {
-	struct reg_cache *cache = calloc(sizeof(struct reg_cache), 1);
+	struct reg_cache *cache = calloc(1, sizeof(struct reg_cache));
 	struct reg *reg_list = calloc(TOTAL_REG_NUM, sizeof(struct reg));
 	struct nds32_reg *reg_arch_info = calloc(TOTAL_REG_NUM, sizeof(struct nds32_reg));
 	int i;
@@ -409,7 +409,7 @@ static struct reg_cache *nds32_build_reg_cache(struct target *target,
 		reg_list[i].size = nds32_reg_size(i);
 		reg_list[i].arch_info = &reg_arch_info[i];
 
-		reg_list[i].reg_data_type = calloc(sizeof(struct reg_data_type), 1);
+		reg_list[i].reg_data_type = calloc(1, sizeof(struct reg_data_type));
 
 		if (reg_arch_info[i].num >= FD0 && reg_arch_info[i].num <= FD31) {
 			reg_list[i].value = reg_arch_info[i].value;


### PR DESCRIPTION
This should fix the warnings introduced with GCC 14 (?) -Werror=calloc-transposed-args and therefore breaks the builds

```
....
src/flash/nor/max32xxx.c: In function 'max32xxx_flash_bank_command':
src/flash/nor/max32xxx.c:90:30: error: 'calloc' sizes specified with 'sizeof' in the earlier argument and not in the later argument [-Werror=calloc-transposed-args]
   90 |         info = calloc(sizeof(struct max32xxx_flash_bank), 1);
      |                              ^~~~~~
src/flash/nor/max32xxx.c:90:30: note: earlier argument should specify number of elements, later size of each element
src/target/arc_jtag.c: In function 'arc_jtag_read_registers':
src/flash/nor/stm32f2x.c: In function 'stm32x_probe':
src/flash/nor/stellaris.c: In function 'stellaris_flash_bank_command':
src/target/arc_jtag.c:301:43: error: 'calloc' sizes specified with 'sizeof' in the earlier argument and not in the later argument [-Werror=calloc-transposed-args]
  301 |         uint8_t *data_buf = calloc(sizeof(uint8_t), count * 4);
      |                                           ^~~~~~~
src/target/arc_jtag.c:301:43: note: earlier argument should specify number of elements, later size of each element
src/flash/nor/stldr_driver.c: In function 'stldr_parse':
src/flash/nor/stldr_driver.c:265:71: error: 'calloc' sizes specified with 'sizeof' in the earlier argument and not in the later argument [-Werror=calloc-transposed-args]
  265 |                         struct stldr_section *section = calloc(sizeof(struct stldr_section), 1);
      |                                                                       ^~~~~~
src/flash/nor/stellaris.c:456:40: error: 'calloc' sizes specified with 'sizeof' in the earlier argument and not in the later argument [-Werror=calloc-transposed-args]
  456 |         stellaris_info = calloc(sizeof(struct stellaris_flash_bank), 1);
  ...
  ```

Not sure if this PR is wanted. If there is a different fix from the openocd source simply close this PR.
Thanks!