### PR TITLE
stm32h5x: fix errors due to deprecated syntax.

### DIFF
--- a/tcl/target/stm32h5x.cfg
+++ b/tcl/target/stm32h5x.cfg
@@ -125,9 +125,7 @@ proc stm32h5x_get_chipname {} {
 
 # like mrw, but with target selection
 proc stm32h5x_mrw {used_target reg} {
-	set value ""
-	$used_target mem2array value 32 $reg 1
-	return $value(0)
+	return [$used_target read_memory $reg 32 1]
 }
 
 # like mmw, but with target selection
@@ -265,12 +263,6 @@ $_CHIPNAME.cpu configure -event examine-end {
 
 $_CHIPNAME.cpu configure -event halted {
 	stm32h5x_enter_debug
-}
-
-$_CHIPNAME.cpu configure -event trace-config {
-	# Set TRACE_IOEN and TRACE_EN; TRACE_MODE is set to async; when using sync
-	# change this value accordingly to configure trace pins assignment
-	stm32h5x_mmw $_CHIPNAME.ap0 0xE0044004 0x00000030 0
 }
 
 proc get_pstate {} {


### PR DESCRIPTION
`trace-config` event is deprecated and prints an ugly error message, recommending using `pre-enable` and similar events, for SWO/TPIU. Even if this was not the case, I think this event is not at the right place because access to TPIU registers in `COMMAND_HANDLER(handle_arm_tpiu_swo_enable)` is done *before* the event callback is ignored, and TPIU is not clocked without TRACE_EN so the accesses fail. I discovered this while trying to use SWO in my STH32H5x custom board. The right way is to use a `pre-event` when configuring swo, so either removing this callback definition altogether (as his PR does) or including swo configuration i this file (as `sstm32h7x.cfg` does).

`mem2array` is deprecated and returns no value. This means the read-modify-write logic in `stm32h5x_mmw` does not work. This is only used in two places where reset value is zero, so no real harm is done, but it breaks other potential uses of `stm32h5x_mmw` (including the ones which were on the `trace-config`, if it was working). This PR changes it to use `read_memory`, which is current.